### PR TITLE
Added explicitly defaulted constructor to error class

### DIFF
--- a/error.hpp
+++ b/error.hpp
@@ -41,6 +41,7 @@ class Error {
 public:
     Error();
     Error(const Error& src) = default;
+    Error(Error&&) noexcept = default;
     Error(bool critical, const std::string& message,
           const std::string& filename, const std::string& function, int line);
     Error& operator=(const Error&) = default;


### PR DESCRIPTION
Since the first template argument of `expected` can not always meet `is_nothrow_move_constructible` (e.g. `HTTPParams`), class `Error` (used with `expected`) needs to meet `is_nothrow_move_constructible` to prevent [the assignment operator of `expect` being defined as deleted](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0323r9.html#expected.object.assign). This actually fixes the build failure with updated expected-lite 0.3.0.
Note that `Error(Error&&) = default;` could be sufficient as it would be implicit `noexcept`. The explicit `noexcept` should make the intention more explicit.