### PR TITLE
Fix URL::Encode crash on Windows

### DIFF
--- a/url.cpp
+++ b/url.cpp
@@ -89,7 +89,7 @@ string URL::Encode(const string& s, bool full) {
         string::value_type c = (*i);
 
         // Keep alphanumeric and other accepted characters intact
-        if (!full && (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')) {
+        if (!full && (isalnum((unsigned char)c) || c == '-' || c == '_' || c == '.' || c == '~')) {
             escaped << c;
             continue;
         }

--- a/url_test.cpp
+++ b/url_test.cpp
@@ -106,6 +106,9 @@ TEST(TestURL, EncodeNotFull)
 
   enc = URL::Encode("{\"k1\": \"v\", \"k2\": 123}", false);
   ASSERT_EQ(enc, "%7B%22k1%22%3A%20%22v%22%2C%20%22k2%22%3A%20123%7D");
+
+  enc = URL::Encode("⌘", false);
+  ASSERT_EQ(enc, "%E2%8C%98");
 }
 
 TEST(TestURL, EncodeFull)
@@ -124,4 +127,7 @@ TEST(TestURL, EncodeFull)
 
   enc = URL::Encode("{\"k1\": \"v\", \"k2\": 123}", true);
   ASSERT_EQ(enc, "%7B%22%6B%31%22%3A%20%22%76%22%2C%20%22%6B%32%22%3A%20%31%32%33%7D");
+
+  enc = URL::Encode("⌘", false);
+  ASSERT_EQ(enc, "%E2%8C%98");
 }


### PR DESCRIPTION
On Windows, the higher characters of a UTF-8 sequence would get converted to a large negative int before being passed to isalnum(). This would fail a sanity check ("undefined behaviour"), causing an assert violation. First casting to unsigned char fixes this.