### PR TITLE
Convert the datastore write "pauser" to be a "transaction"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library( # Sets the name of the library.
              ${SOURCES} )
 
 SET(GCC_COVERAGE_COMPILE_FLAGS "-Wall -fprofile-arcs -ftest-coverage -g -O0")
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread")
 
 SET(GCC_COVERAGE_LINK_FLAGS    "-lgcov --coverage")
 #SET(GCC_COVERAGE_LINK_FLAGS    "-lclang_rt.profile_osx -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0/lib/darwin")

--- a/psicash_test.cpp
+++ b/psicash_test.cpp
@@ -1937,7 +1937,7 @@ TEST_F(TestPsiCash, RefreshStateOffline) {
         request_attempted = true;
         return HTTPResult();
     };
-    const MakeHTTPRequestFn errorHTTPRequester = [&request_attempted](const HTTPParams&) -> HTTPResult {
+    const MakeHTTPRequestFn errorHTTPRequester = [](const HTTPParams&) -> HTTPResult {
         auto res = HTTPResult();
         res.code = HTTPResult::RECOVERABLE_ERROR;
         res.error = "test";
@@ -2133,10 +2133,10 @@ TEST_F(TestPsiCash, NewExpiringPurchase) {
     ASSERT_EQ(pc.Balance(), initial_balance);
 }
 
-TEST_F(TestPsiCash, NewExpiringPurchasePauserCommitBug) {
+TEST_F(TestPsiCash, NewExpiringPurchaseTransactionCommitBug) {
     // Bug test: When a kHTTPStatusTooManyRequests response (or any non-success, but
     // especially that one) was received, the updated balance received in the response
-    // would be written to the datastore, but the WritePauser would not be committed, so
+    // would be written to the datastore, but the Transaction would not be committed, so
     // the change would be lost and the UI wouldn't update until a RefreshState request
     // was made.
 

--- a/utils.hpp
+++ b/utils.hpp
@@ -50,7 +50,7 @@ std::string Stringer(const T& value, const Args& ... args) {
 /// }
 #define SYNCHRONIZE_BLOCK(m) for(std::unique_lock<std::recursive_mutex> lk(m); lk; lk.unlock())
 /// Synchronize the current scope using the given mutex.
-#define SYNCHRONIZE(m) std::unique_lock<std::recursive_mutex> synchronize_lock(m)
+#define SYNCHRONIZE(m) std::lock_guard<std::recursive_mutex> synchronize_lock(m)
 
 /// Tests if the given filepath+name exists.
 bool FileExists(const std::string& filename);


### PR DESCRIPTION
This is to mitigate the possibilty of race conditions when writing multiple values and trying to read one of them. For example:
thread 1: begin transaction
thread 1: write is_account=true
thread 2: read is_account and account_username; get true and ""
thread 1: write account_username="blah"
thread 1: commit (or roll back)

The new implementation will require thread 2 to wait until thread 1 has finished its transaction.