### PR TITLE
check the failbit after closing the datastore file

### DIFF
--- a/datastore.cpp
+++ b/datastore.cpp
@@ -230,6 +230,10 @@ static Error FileStore(int transaction_depth, const string& file_path, const jso
 
     f.close();
 
+    if (f.fail()) {
+        return MakeCriticalError(utils::Stringer("temp_file_path close failed; errno=", errno));
+    }
+
     /*
     Rename temp to commit
     */


### PR DESCRIPTION
This is per the [documentation](https://www.cplusplus.com/reference/fstream/ofstream/close/) that indicates that the failbit is set if close fails.