### PR TITLE
Reduce datastore writes

### DIFF
--- a/datastore.hpp
+++ b/datastore.hpp
@@ -66,8 +66,8 @@ public:
     /// EndTransaction is called. Transactions are re-enterable, but not nested.
     /// NOTE: Failing to call EndTransaction will result in undefined behaviour.
     void BeginTransaction();
-    /// Ends an ongoing transaction writing. If commit is true, it writes the changes
-    /// immediately; if false it discards the changes.
+    /// Ends an ongoing transaction. If commit is true, it writes the changes immediately;
+    /// if false it discards the changes.
     /// Committing or rolling back inner transactions does nothing. Any errors during
     /// inner transactions that require the outermost transaction to be rolled back must
     /// be handled by the caller.
@@ -121,6 +121,7 @@ private:
     mutable std::recursive_mutex mutex_;
     std::unique_lock<std::recursive_mutex> explicit_lock_;
     int transaction_depth_;
+    bool transaction_dirty_;
 
     std::string file_path_;
     json json_;

--- a/psicash.hpp
+++ b/psicash.hpp
@@ -194,7 +194,7 @@ public:
 
     /// Set values that will be included in the request metadata. This includes
     /// client_version, client_region, sponsor_id, and propagation_channel_id.
-    error::Error SetRequestMetadataItem(const std::string& key, const std::string& value);
+    error::Error SetRequestMetadataItems(const std::map<std::string, std::string>& items);
 
     /// Set current UI locale.
     error::Error SetLocale(const std::string& locale);

--- a/psicash_test.cpp
+++ b/psicash_test.cpp
@@ -279,7 +279,7 @@ TEST_F(TestPsiCash, SetHTTPRequestFn) {
     }
 }
 
-TEST_F(TestPsiCash, SetRequestMetadataItem) {
+TEST_F(TestPsiCash, SetRequestMetadataItems) {
     PsiCashTester pc;
     auto err = pc.Init(TestPsiCash::UserAgent(), GetTempDir().c_str(), nullptr, false);
     ASSERT_FALSE(err);
@@ -287,11 +287,19 @@ TEST_F(TestPsiCash, SetRequestMetadataItem) {
     auto j = pc.user_data().GetRequestMetadata();
     ASSERT_EQ(j.size(), 0);
 
-    err = pc.SetRequestMetadataItem("k", "v");
+    err = pc.SetRequestMetadataItems({{"k", "v"}});
     ASSERT_FALSE(err);
 
     j = pc.user_data().GetRequestMetadata();
     ASSERT_EQ(j["k"], "v");
+
+    err = pc.SetRequestMetadataItems({{"a", "b"}, {"x", "y"}});
+    ASSERT_FALSE(err);
+
+    j = pc.user_data().GetRequestMetadata();
+    ASSERT_EQ(j["k"], "v");
+    ASSERT_EQ(j["a"], "b");
+    ASSERT_EQ(j["x"], "y");
 }
 
 TEST_F(TestPsiCash, SetLocale) {
@@ -934,7 +942,7 @@ TEST_F(TestPsiCash, ModifyLandingPage) {
     // With metadata
     //
 
-    err = pc.SetRequestMetadataItem("k", "v");
+    err = pc.SetRequestMetadataItems({{"k", "v"}, {"x", "y"}});
     ASSERT_FALSE(err);
     url_in = {"https://asdf.sadf.gf", "", ""};
     res = pc.ModifyLandingPage(url_in.ToString());
@@ -942,7 +950,7 @@ TEST_F(TestPsiCash, ModifyLandingPage) {
     url_out.Parse(*res);
     ASSERT_EQ(url_out.scheme_host_path_, url_in.scheme_host_path_);
     ASSERT_EQ(url_out.fragment_, url_in.fragment_);
-    ASSERT_THAT(TokenPayloadsMatch(url_out.query_.substr(key_part.length()), R"({"metadata":{"k":"v"},"tokens":"kEarnerTokenType"})"_json), IsEmpty());
+    ASSERT_THAT(TokenPayloadsMatch(url_out.query_.substr(key_part.length()), R"({"metadata":{"k":"v","x":"y"},"tokens":"kEarnerTokenType"})"_json), IsEmpty());
 
     //
     // Errors
@@ -1077,7 +1085,7 @@ TEST_F(TestPsiCash, GetRewardedActivityData) {
     ASSERT_TRUE(res);
     ASSERT_EQ(*res, base64::B64Encode(utils::Stringer(R"({"metadata":{"user_agent":")", TestPsiCash::UserAgent(), R"(","v":1},"tokens":"kEarnerTokenType","v":1})")));
 
-    err = pc.SetRequestMetadataItem("k", "v");
+    err = pc.SetRequestMetadataItems({{"k", "v"}});
     ASSERT_FALSE(err);
     res = pc.GetRewardedActivityData();
     ASSERT_TRUE(res);

--- a/test_helpers.hpp
+++ b/test_helpers.hpp
@@ -68,8 +68,16 @@ class TempDir
         return dev ? ".dev" : ".prod";
     }
 
+    std::string DatastoreFilepath(const std::string& datastore_root, const char* suffix) {
+        return datastore_root + "/psicashdatastore" + suffix;
+    }
+
+    std::string DatastoreFilepath(const std::string& datastore_root, const std::string& suffix) {
+        return DatastoreFilepath(datastore_root, suffix.c_str());
+    }
+
     std::string DatastoreFilepath(const std::string& datastore_root, bool dev) {
-        return datastore_root + "/psicashdatastore" + GetSuffix(dev);
+        return DatastoreFilepath(datastore_root, GetSuffix(dev));
     }
 
     bool Write(const std::string& datastore_root, bool dev, const std::string& s) {


### PR DESCRIPTION
These changes reduce the need for frequent datastore writes by not writing when data hasn't changed, and by batching request metadata setting. This will hopefully partially mitigate the datastore corruption errors we sometimes see.